### PR TITLE
minijinja 2.3.1 (new formula)

### DIFF
--- a/Formula/m/minijinja.rb
+++ b/Formula/m/minijinja.rb
@@ -1,0 +1,21 @@
+class Minijinja < Formula
+  desc "Render Jinja2 templates directly from the command line to stdout"
+  homepage "https://github.com/mitsuhiko/minijinja"
+  url "https://github.com/mitsuhiko/minijinja/archive/refs/tags/2.3.1.tar.gz"
+  sha256 "c933a1d9f53de26bb776a61b9346e0b202c332b4ff1309db5d0178a9b603ca06"
+  license "Apache-2.0"
+  head "https://github.com/mitsuhiko/minijinja.git", branch: "main"
+
+  depends_on "rust" => :build
+
+  def install
+      cd "minijinja-cli" do
+        system "cargo", "install", *std_cargo_args
+      end
+      bin.install "target/release/minijinja-cli" => "minijinja"
+    end
+
+  test do
+    assert_match "minijinja-cli #{version}", shell_output("#{bin}/minijinja --version")
+  end
+end


### PR DESCRIPTION
[MiniJinja](https://github.com/mitsuhiko/minijinja) is a rust framework but it also provides a CLI tool called `minijinja-cli`, I've renamed the binary from `minijinja-cli` to `minijinja`.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
